### PR TITLE
Add curl to dependencies

### DIFF
--- a/Prepare_toolchain.sh
+++ b/Prepare_toolchain.sh
@@ -11,4 +11,4 @@ apt-get -y --no-install-recommends --fix-missing install \
 	bsdtar mtools u-boot-tools pv bc \
 	gcc automake make \
 	lib32z1 lib32z1-dev qemu-user-static \
-	dosfstools libncurses5-dev
+	dosfstools libncurses5-dev curl


### PR DESCRIPTION
My Ubuntu 16.04 system did not have curl preinstalled and the script chain failed at trying to unpack the toolchain. This will make sure curl is installed.